### PR TITLE
Add textured overlay to lane background

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -25,7 +25,9 @@
     .stat .v{font-variant-numeric:tabular-nums;font-weight:700;font-size:18px}
 
     /* Вертикальная пит-лейн для телефонов */
-    .lane{position:relative;height:min(78vh,720px);border-radius:16px;overflow:hidden;border:1px solid #cbd5e1;background:linear-gradient(#f1f5f9,#e2e8f0)}
+    .lane{position:relative;z-index:0;height:min(78vh,720px);border-radius:16px;overflow:hidden;border:1px solid #cbd5e1;background:linear-gradient(#f1f5f9,#e2e8f0)}
+    .lane::before{content:"";position:absolute;inset:0;pointer-events:none;border-radius:inherit;z-index:0;background:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180' viewBox='0 0 180 180'%3E%3Cg fill='%23a5b4fc' fill-opacity='.18'%3E%3Ccircle cx='18' cy='28' r='1.8'/%3E%3Ccircle cx='84' cy='20' r='1.3'/%3E%3Ccircle cx='140' cy='46' r='1.5'/%3E%3Ccircle cx='44' cy='88' r='1.6'/%3E%3Ccircle cx='126' cy='96' r='1.7'/%3E%3Ccircle cx='34' cy='148' r='1.4'/%3E%3Ccircle cx='104' cy='152' r='1.5'/%3E%3Ccircle cx='168' cy='132' r='1.9'/%3E%3C/g%3E%3Cg fill='%23e2e8f0' fill-opacity='.14'%3E%3Ccircle cx='58' cy='12' r='1.2'/%3E%3Ccircle cx='12' cy='98' r='1.1'/%3E%3Ccircle cx='96' cy='68' r='1.3'/%3E%3Ccircle cx='170' cy='86' r='1.2'/%3E%3Ccircle cx='70' cy='134' r='1.4'/%3E%3Ccircle cx='150' cy='24' r='1'/%3E%3Ccircle cx='112' cy='118' r='1.1'/%3E%3Ccircle cx='46' cy='176' r='1.2'/%3E%3C/g%3E%3C/svg%3E"),repeating-linear-gradient(12deg,rgba(15,23,42,.28)0 18px,rgba(30,41,59,.44)18px 36px,rgba(148,163,184,.25)36px 54px);background-size:140px 140px,48px 48px;background-position:32px 18px,0 0;background-repeat:repeat;opacity:.4;mix-blend-mode:multiply}
+    .lane .centerline,.lane .box{z-index:1}
     .lane .centerline{position:absolute;left:50%;top:0;bottom:0;width:2px;transform:translateX(-50%);background:#cbd5e1}
     .lane .box{position:absolute;left:0;right:0;top:50%;height:200px;transform:translateY(-50%);border-top:5px dashed rgba(234,179,8,.9);border-bottom:5px dashed rgba(234,179,8,.9)}
 


### PR DESCRIPTION
## Summary
- add a pseudo-element overlay on the pit lane container with cold diagonal striping and subtle noise
- ensure the center line and pit box remain above the decorative overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca71e3c774832c819eda225e5503a1